### PR TITLE
Add sqlite support and JSON pretty print

### DIFF
--- a/sqline.py
+++ b/sqline.py
@@ -22,7 +22,7 @@ def get_engine_string(dialect, username, password, endpoint, name, port):
 @click.option('--port', envvar='DB_PORT')
 @click.option('--dialect', envvar='DB_DIALECT')
 @click.option('-o', '--output')
-@click.option('-p', '--pretty', type=bool, default=True)
+@click.option('-p', '--pretty', type=bool, default=True, required=False)
 def main(query, username, password, endpoint, name, port, dialect, output, pretty):
     """Console script for sqline."""
 

--- a/sqline.py
+++ b/sqline.py
@@ -1,12 +1,15 @@
 import click
 from sqlalchemy import create_engine
 import pandas as pd
-
+from json import dumps, loads
 
 def get_engine_string(dialect, username, password, endpoint, name, port):
-    engine = """{}://{}:{}@{}:{}/{}""".format(
-        dialect, username, password, endpoint, port, name
-    )
+    if dialect == 'sqlite':
+        engine = """sqlite:////{}""".format(name)
+    else:
+        engine = """{}://{}:{}@{}:{}/{}""".format(
+            dialect, username, password, endpoint, port, name
+        )
     return engine
 
 
@@ -19,7 +22,8 @@ def get_engine_string(dialect, username, password, endpoint, name, port):
 @click.option('--port', envvar='DB_PORT')
 @click.option('--dialect', envvar='DB_DIALECT')
 @click.option('-o', '--output')
-def main(query, username, password, endpoint, name, port, dialect, output):
+@click.option('-p', '--pretty', type=bool, default=True)
+def main(query, username, password, endpoint, name, port, dialect, output, pretty):
     """Console script for sqline."""
 
     if not query:
@@ -35,6 +39,9 @@ def main(query, username, password, endpoint, name, port, dialect, output):
     if output == 'csv':
         click.echo(result.to_csv())
     elif output == 'json':
-        click.echo(result.to_json(orient='records', lines=True))
+        if pretty:
+            click.echo(dumps(loads(result.to_json(orient='records', lines=False)), indent=4, sort_keys=True))
+        else:
+            click.echo(result.to_json(orient='records', lines=False))
     else:
         click.echo(result)

--- a/sqline.py
+++ b/sqline.py
@@ -42,6 +42,6 @@ def main(query, username, password, endpoint, name, port, dialect, output, prett
         if pretty:
             click.echo(dumps(loads(result.to_json(orient='records', lines=False)), indent=4, sort_keys=True))
         else:
-            click.echo(result.to_json(orient='records', lines=False))
+            click.echo(result.to_json(orient='records', lines=True))
     else:
         click.echo(result)


### PR DESCRIPTION
Hello @davidgasquez,

I've added two new features to this script:

* **Sqlite support**.
* **JSON pretty printing**.

# Sqlite support
As specified in [SQL Alchemy docs](http://docs.sqlalchemy.org/en/latest/core/engines.html):
> As SQLite connects to local files, the URL format is slightly different. The “file” portion of the URL is the filename of the database. For a relative file path, this requires three slashes.

So I've modified the `get_engine_function` to support this URL format:
```python
def get_engine_string(dialect, username, password, endpoint, name, port):
    if dialect == 'sqlite':
        engine = """sqlite:////{}""".format(name)
    else:
        engine = """{}://{}:{}@{}:{}/{}""".format(
            dialect, username, password, endpoint, port, name
        )
    return engine
```

# JSON pretty printing
I've added an optional parameter to pretty print JSON output. 
```python
@click.option('-p', '--pretty', type=bool, default=True, required=False)
```

Its optional value is set to `True` but it can be set to `False` in command line:
```shellsession
$ sqline "select * from agent" -o json --pretty=False
```

I hope this can be useful 😉 
Marta